### PR TITLE
missing message for `\n`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.sh
 django.po
 djangojs.po
+.idea/*

--- a/analytics-dashboard.po
+++ b/analytics-dashboard.po
@@ -260,7 +260,7 @@ msgid ""
 "\n"
 "        Select %(level)s\n"
 "    "
-msgstr "%(level)s\nを選択"
+msgstr "\n%(level)s\nを選択"
 
 #: courses/templates/courses/_graded_content_nav.html:31
 #: courses/templates/courses/_tags_content_nav.html:23


### PR DESCRIPTION
We tried to run po merge script, but we got an error. We fixed the `\n` line.
Please check this line `msgstr "\n%(level)s\nを選択"`. 